### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,10 +22,8 @@ services:
         image: postgres:17-alpine
         container_name: postgres
         restart: unless-stopped
-        environment:
-            POSTGRES_DB: ${POSTGRES_DB:-open_archive}
-            POSTGRES_USER: ${POSTGRES_USER:-admin}
-            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
+        env_file:
+            - .env
         volumes:
             - pgdata:/var/lib/postgresql/data
         networks:


### PR DESCRIPTION
Defining custom POSTGRES_PASSWORD under environment doesn't work. Changing section to reference .env file preserves function while allowing custom passwords. Resolves issue #253.