### PR TITLE
enable meilisearch-dumpless-upgrade

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,8 @@ services:
         restart: unless-stopped
         environment:
             MEILI_MASTER_KEY: ${MEILI_MASTER_KEY:-aSampleMasterKey}
+            MEILI_SCHEDULE_SNAPSHOT: 3600
+            MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE: "true"
         volumes:
             - meilidata:/meili_data
         networks:


### PR DESCRIPTION
Meilisearch [Dumpless upgrade](https://www.meilisearch.com/docs/learn/update_and_migration/updating#dumpless-upgrade) makes it more easier upgrading it.

This PR enables schedules snapshots, which are helpful if the experimental feature gets stuck. It also enables the dumpless upgrade which should eliminate all the manual steps for upgrading (tried that on another meili instance when upgrading from 1.15 to 1.35).