### PR TITLE
feat(types): update license types and prepare @open-archiver/types

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -6,7 +6,7 @@ export default defineConfig({
 			'script',
 			{
 				defer: '',
-				src: 'https://analytics.zenceipt.com/script.js',
+				src: 'https://analytics.openarchiver.com/script.js',
 				'data-website-id': '2c8b452e-eab5-4f82-8ead-902d8f8b976f',
 			},
 		],

--- a/packages/types/LICENSE
+++ b/packages/types/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2026 Open Archiver
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,17 @@
+# @open-archiver/types
+
+This package contains shared TypeScript type definitions for the Open Archiver project.
+
+## Installation
+
+```bash
+npm install @open-archiver/types
+```
+
+## Usage
+
+Import the types you need in your TypeScript files:
+
+```typescript
+import { User, Email } from '@open-archiver/types';
+```

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,10 +1,15 @@
 {
 	"name": "@open-archiver/types",
-	"version": "0.1.0",
-	"private": true,
-	"license": "SEE LICENSE IN LICENSE file",
+	"version": "0.1.2",
+	"license": "MIT License",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
+	"files": [
+		"dist"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
 	"scripts": {
 		"build": "tsc",
 		"dev": "tsc --watch"

--- a/packages/types/src/license.types.ts
+++ b/packages/types/src/license.types.ts
@@ -22,15 +22,49 @@ export interface LicenseFilePayload {
 }
 
 /**
- * The structure of the cached response from the License Server.
+ * Request body sent to the license server's POST /api/v1/ping endpoint.
  */
-export interface LicenseStatusPayload {
-	status: 'VALID' | 'REVOKED';
-	gracePeriodEnds?: string; // ISO 8601, only present if REVOKED
+export interface LicensePingRequest {
+	/** UUID of the license, taken from the license.jwt payload. */
+	licenseId: string;
+	/** Current number of unique archived mailboxes on this instance. */
+	activeSeats: number;
+	/** Version string of the running Open Archiver instance. */
+	version: string;
 }
 
 /**
- * The consolidated license status object returned by the API.
+ * Successful response body from the license server's POST /api/v1/ping endpoint.
+ *
+ * - `"VALID"` — license is active. If `gracePeriodEnds` is present, seats exceed
+ *   the plan limit and the grace period deadline is included.
+ * - `"INVALID"` — license is revoked, not found, or the overage grace period has
+ *   expired. All enterprise features must be disabled immediately.
+ */
+export interface LicensePingResponse {
+	status: 'VALID' | 'INVALID';
+	/** ISO 8601 UTC timestamp. Present only when status is "VALID" and activeSeats > planSeats. */
+	gracePeriodEnds?: string;
+	/** The current plan seat limit from the license server. */
+	planSeats?: number;
+}
+
+/**
+ * The structure of the locally cached license-status.json file.
+ * Written after each successful phone-home call.
+ */
+export interface LicenseStatusPayload {
+	status: 'VALID' | 'INVALID';
+	/** ISO 8601 UTC timestamp. Present when the instance is in a seat-overage grace period. */
+	gracePeriodEnds?: string;
+	/** ISO 8601 UTC timestamp of when this status was last successfully fetched. */
+	lastCheckedAt?: string;
+	/** The current plan seat limit from the license server. */
+	planSeats: number;
+}
+
+/**
+ * The consolidated license status object returned by the GET /enterprise/status/license-status API.
  */
 export interface ConsolidatedLicenseStatus {
 	// From the license.jwt file
@@ -38,8 +72,9 @@ export interface ConsolidatedLicenseStatus {
 	planSeats: number;
 	expiresAt: string;
 	// From the cached license-status.json
-	remoteStatus: 'VALID' | 'REVOKED' | 'UNKNOWN';
+	remoteStatus: 'VALID' | 'INVALID' | 'UNKNOWN';
 	gracePeriodEnds?: string;
+	lastCheckedAt?: string;
 	// Calculated values
 	activeSeats: number;
 	isExpired: boolean;


### PR DESCRIPTION

- Add `LicensePingRequest` and `LicensePingResponse` interfaces for the license server ping endpoint
- Update `LicenseStatusPayload` to include `lastCheckedAt` and `planSeats` fields, and change status from `REVOKED` to `INVALID`
- Update `ConsolidatedLicenseStatus` to reflect `INVALID` status and add `lastCheckedAt`
- Bump `@open-archiver/types` version from 0.1.0 to 0.1.2, set license to MIT, make package public, and add `files` field