### PR TITLE
fix: support non-ASCII filenames in file download headers (RFC 5987)

### DIFF
--- a/packages/backend/src/api/controllers/storage.controller.ts
+++ b/packages/backend/src/api/controllers/storage.controller.ts
@@ -40,7 +40,8 @@ export class StorageController {
 
 			const fileStream = await this.storageService.get(safePath);
 			const fileName = path.basename(safePath);
-			res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
+			const encodedFileName = encodeURIComponent(fileName);
+			res.setHeader('Content-Disposition', `attachment; filename*=UTF-8''${encodedFileName}`);
 			fileStream.pipe(res);
 		} catch (error) {
 			console.error('Error downloading file:', error);


### PR DESCRIPTION
## Problem

When downloading attachments or EML files with non-ASCII characters in their filename (e.g. German umlauts like `ä`, `ö`, `ü`), the backend throws a Node.js `ERR_INVALID_CHAR` error and returns HTTP 500:

```
Error downloading file: TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["Content-Disposition"]                                                                                                     
     at ServerResponse.setHeader (node:_http_outgoing:703:3)                                                                                                                                                           
     at downloadFile (/app/packages/backend/dist/api/controllers/storage.controller.js:70:17)    
```

This affects all file downloads via `GET /api/v1/storage/download` where the filename contains characters outside the ASCII range.

Closes #182

## Root Cause

`storage.controller.ts` sets the header as:

    Content-Disposition: attachment; filename="Geschäftsbericht.pdf"

Node.js rejects non-ASCII bytes in HTTP headers.

## Fix

Encode the filename using RFC 5987 (`filename*=UTF-8''...`), which is supported by all modern browsers (Firefox 5+, Chrome 13+, Safari 6+):

    Content-Disposition: attachment; filename*=UTF-8''Gesch%C3%A4ftsbericht.pdf

## Changes

- `packages/backend/src/api/controllers/storage.controller.ts`: 
  2-line change

## Prior Work

A nearly identical fix was independently implemented by @prinsss in their fork (commit prinsss/OpenArchiver@021f34f, October 2025) but was never submitted as a PR to this repository.
```