### PR TITLE
fix: serialize raw email content as base64 string to prevent RangeError on large emails

### DIFF
--- a/packages/backend/src/services/ArchivedEmailService.ts
+++ b/packages/backend/src/services/ArchivedEmailService.ts
@@ -166,12 +166,12 @@ export class ArchivedEmailService {
 
 		const storage = new StorageService();
 		const rawStream = await storage.get(email.storagePath);
-		const raw = await streamToBuffer(rawStream as Readable);
+		const rawBuffer = await streamToBuffer(rawStream as Readable);
 
 		const mappedEmail = {
 			...email,
 			recipients: this.mapRecipients(email.recipients),
-			raw,
+			raw: rawBuffer.toString('base64'),
 			thread: threadEmails,
 			tags: (email.tags as string[] | null) || null,
 			path: email.path || null,

--- a/packages/frontend/src/lib/components/custom/EmailPreview.svelte
+++ b/packages/frontend/src/lib/components/custom/EmailPreview.svelte
@@ -7,7 +7,7 @@
 	let {
 		raw,
 		rawHtml,
-	}: { raw?: Buffer | { type: 'Buffer'; data: number[] } | undefined; rawHtml?: string } =
+	}: { raw?: string | Buffer | { type: 'Buffer'; data: number[] } | undefined; rawHtml?: string } =
 		$props();
 
 	let parsedEmail: Email | null = $state(null);
@@ -79,7 +79,11 @@
 			if (raw) {
 				try {
 					let buffer: Uint8Array;
-					if ('type' in raw && raw.type === 'Buffer') {
+					if (typeof raw === 'string') {
+						const binary = atob(raw);
+						buffer = new Uint8Array(binary.length);
+						for (let i = 0; i < binary.length; i++) buffer[i] = binary.charCodeAt(i);
+					} else if ('type' in raw && raw.type === 'Buffer') {
 						buffer = new Uint8Array(raw.data);
 					} else {
 						buffer = new Uint8Array(raw as Buffer);

--- a/packages/frontend/src/routes/dashboard/archived-emails/[id]/+page.svelte
+++ b/packages/frontend/src/routes/dashboard/archived-emails/[id]/+page.svelte
@@ -93,7 +93,11 @@
 
 			try {
 				let buffer: Uint8Array;
-				if (raw && typeof raw === 'object' && 'type' in raw && raw.type === 'Buffer') {
+				if (typeof raw === 'string') {
+					const binary = atob(raw);
+					buffer = new Uint8Array(binary.length);
+					for (let i = 0; i < binary.length; i++) buffer[i] = binary.charCodeAt(i);
+				} else if (typeof raw === 'object' && 'type' in raw && raw.type === 'Buffer') {
 					buffer = new Uint8Array(
 						(raw as unknown as { type: 'Buffer'; data: number[] }).data
 					);

--- a/packages/types/src/archived-emails.types.ts
+++ b/packages/types/src/archived-emails.types.ts
@@ -46,7 +46,7 @@ export interface ArchivedEmail {
 	isJournaled: boolean | null;
 	archivedAt: Date;
 	attachments?: Attachment[];
-	raw?: Buffer;
+	raw?: string;
 	thread?: ThreadEmail[];
 	path: string | null;
 	tags: string[] | null;


### PR DESCRIPTION
## Problem

Opening archived emails in the UI fails with HTTP 500 for emails with large raw EML content. The backend logs show:

    RangeError: Invalid array length
        at Buffer.toJSON (node:buffer:1158:15)
        at JSON.stringify (<anonymous>)
        at ServerResponse.json (express/lib/response.js)
        at getArchivedEmailById (archived-email.controller.js:41)

The frontend displays "Email not found" for any non-200 response, so affected emails appear missing even though they exist in the database.

## Root Cause

`ArchivedEmailService.getArchivedEmailById` includes the raw EML content as a `Buffer` in the JSON response. When Express calls `JSON.stringify`, Node.js internally invokes `Buffer.toJSON()` which attempts to create a plain JavaScript array with `new Array(buffer.length)`. For large email files this throws `RangeError: Invalid array length`.

## Fix

Convert the raw EML `Buffer` to a base64 string before including it in the API response. This avoids `Buffer.toJSON()` entirely and is the standard approach for transferring binary data over JSON REST APIs.

Both frontend consumers (`EmailPreview.svelte` and the email detail page) are updated to decode the base64 string back to `Uint8Array` before passing it to `postal-mime` for parsing. Backwards compatibility with the old `{type: 'Buffer', data: [...]}` format is retained for any existing clients.

## Changes

- `packages/backend/src/services/ArchivedEmailService.ts`: convert raw Buffer to base64 string via `rawBuffer.toString('base64')`
- `packages/types/src/archived-emails.types.ts`: update `raw` field type from `Buffer` to `string`
- `packages/frontend/src/lib/components/custom/EmailPreview.svelte`: handle base64 string input, decode with `atob()`
- `packages/frontend/src/routes/dashboard/archived-emails/[id]/+page.svelte`: same base64 decoding for the attachment parser