### PR TITLE
Add support for UNIX socket connection to PostgreSQL

### DIFF
--- a/docs/user-guides/installation.md
+++ b/docs/user-guides/installation.md
@@ -110,6 +110,7 @@ These variables are used by `docker-compose.yml` to configure the services.
 | `POSTGRES_USER`        | The username for the PostgreSQL database.            | `admin`                                                  |
 | `POSTGRES_PASSWORD`    | The password for the PostgreSQL database.            | `password`                                               |
 | `DATABASE_URL`         | The connection URL for the PostgreSQL database.      | `postgresql://admin:password@postgres:5432/open_archive` |
+| `DATABASE_SOCKET`      | UNIX socket to connect to the PostgreSQL database.   |                                                          |
 | `MEILI_MASTER_KEY`     | The master key for Meilisearch.                      | `aSampleMasterKey`                                       |
 | `MEILI_HOST`           | The host for the Meilisearch service.                | `http://meilisearch:7700`                                |
 | `MEILI_INDEXING_BATCH` | The number of emails to batch together for indexing. | `500`                                                    |
@@ -118,6 +119,8 @@ These variables are used by `docker-compose.yml` to configure the services.
 | `REDIS_USER`           | Optional Redis username if ACLs are used.            |                                                          |
 | `REDIS_PASSWORD`       | The password for the Valkey (Redis) service.         | `defaultredispassword`                                   |
 | `REDIS_TLS_ENABLED`    | Enable or disable TLS for Redis.                     | `false`                                                  |
+
+You need to specify either `DATABASE_URL` or `DATABASE_SOCKET`, the former is preferred over the latter.
 
 #### Storage Settings
 

--- a/packages/backend/drizzle.config.ts
+++ b/packages/backend/drizzle.config.ts
@@ -1,19 +1,14 @@
 import { defineConfig } from 'drizzle-kit';
 import { config } from 'dotenv';
+import { getDatabaseConfig } from 'src/helpers/db';
 
 config();
-
-if (!process.env.DATABASE_URL) {
-	throw new Error('DATABASE_URL is not set in the .env file');
-}
 
 export default defineConfig({
 	schema: './src/database/schema.ts',
 	out: './src/database/migrations',
 	dialect: 'postgresql',
-	dbCredentials: {
-		url: process.env.DATABASE_URL,
-	},
+	dbCredentials: getDatabaseConfig(true),
 	verbose: true,
 	strict: true,
 });

--- a/packages/backend/src/database/index.ts
+++ b/packages/backend/src/database/index.ts
@@ -3,13 +3,10 @@ import postgres from 'postgres';
 import 'dotenv/config';
 
 import * as schema from './schema';
-import { encodeDatabaseUrl } from '../helpers/db';
+import { getDatabaseConfig } from '../helpers/db';
 
-if (!process.env.DATABASE_URL) {
-	throw new Error('DATABASE_URL is not set in the .env file');
-}
-
-const connectionString = encodeDatabaseUrl(process.env.DATABASE_URL);
-const client = postgres(connectionString);
+const databaseConfig = getDatabaseConfig();
+const client =
+	typeof databaseConfig === 'string' ? postgres(databaseConfig) : postgres(databaseConfig);
 export const db = drizzle(client, { schema });
 export type Database = PostgresJsDatabase<typeof schema>;

--- a/packages/backend/src/database/migrate.ts
+++ b/packages/backend/src/database/migrate.ts
@@ -2,17 +2,16 @@ import { migrate } from 'drizzle-orm/postgres-js/migrator';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import { config } from 'dotenv';
-import { encodeDatabaseUrl } from '../helpers/db';
+import { getDatabaseConfig } from '../helpers/db';
 
 config();
 
 const runMigrate = async () => {
-	if (!process.env.DATABASE_URL) {
-		throw new Error('DATABASE_URL is not set in the .env file');
-	}
-
-	const connectionString = encodeDatabaseUrl(process.env.DATABASE_URL);
-	const connection = postgres(connectionString, { max: 1 });
+	const databaseConfig = getDatabaseConfig();
+	const connection =
+		typeof databaseConfig === 'string'
+			? postgres(databaseConfig, { max: 1 })
+			: postgres({ ...databaseConfig, max: 1 });
 	const db = drizzle(connection);
 
 	console.log('Running migrations...');

--- a/packages/backend/src/helpers/db.ts
+++ b/packages/backend/src/helpers/db.ts
@@ -10,3 +10,29 @@ export const encodeDatabaseUrl = (databaseUrl: string): string => {
 		throw new Error('Invalid DATABASE_URL');
 	}
 };
+
+export const getDatabaseConfig = (drizzleConf: boolean = false): string | Record<string, any> => {
+	if (process.env.DATABASE_URL) {
+		return drizzleConf
+			? {
+					url: process.env.DATABASE_URL,
+				}
+			: encodeDatabaseUrl(process.env.DATABASE_URL);
+	} else if (process.env.DATABASE_SOCKET) {
+		return drizzleConf
+			? {
+					host: process.env.DATABASE_SOCKET,
+					database: process.env.POSTGRES_DB,
+					user: process.env.POSTGRES_USER,
+					password: process.env.POSTGRES_PASSWORD,
+				}
+			: {
+					host: process.env.DATABASE_SOCKET,
+					database: process.env.POSTGRES_DB,
+					username: process.env.POSTGRES_USER,
+					password: process.env.POSTGRES_PASSWORD,
+				};
+	} else {
+		throw new Error('Neither DATABASE_URL nor DATABASE_SOCKET is set in the .env file');
+	}
+};


### PR DESCRIPTION
Minimal prototype. I tried to unify the connection code into one place
(src/helpers/db.ts), since Drizzle seems to need slightly different config in
different places (see the issue linked from #343).

Closes #343

Slightly tested in dev mode, migrations work, application starts.

Caveat: This uses the `host` parameter instead of the `path` parameter (see
https://github.com/porsager/postgres#connection-details), since the connection
code (https://github.com/porsager/postgres/blob/master/src/index.js#L468)
builds the "real" socket name from that. If you want, I can extend the code to
check for the path to make this a little bit more "auto-magic".

Feel free to close if you don't want this feature.
