### PR TITLE
fix: increase maxValuesPerFacet to fix Top Senders dashboard panel

### DIFF
--- a/packages/backend/src/services/SearchService.ts
+++ b/packages/backend/src/services/SearchService.ts
@@ -183,6 +183,9 @@ export class SearchService {
 				'userEmail',
 			],
 			sortableAttributes: ['timestamp'],
+			faceting: {
+				maxValuesPerFacet: 10000,
+			},
 		});
 	}
 }


### PR DESCRIPTION
Fixes #357

The Top Senders dashboard panel was only showing senders whose names begin
with digits or the letter "a", while high-frequency senders further in the
alphabet were missing entirely.

**Root cause:** Meilisearch's `maxValuesPerFacet` defaults to `100`, and
facet values are returned in alphabetical order — not by count. The
`getTopSenders()` query received only the first 100 senders alphabetically,
then sorted those by count client-side. For large mailboxes with many unique
senders, this meant the actual top senders were never in the result set.

**Fix:** Set `maxValuesPerFacet: 10000` in `configureEmailIndex()` so
Meilisearch returns enough facet values for the client-side sort to produce
a correct top-10.

This setting only activates when a query explicitly requests facets. The
email content search does not use facets and is completely unaffected —
`facets: [...]` appears only in `getTopSenders()` across the entire codebase.